### PR TITLE
Suggestion for ECL

### DIFF
--- a/src/rnd/rnd.lisp
+++ b/src/rnd/rnd.lisp
@@ -8,10 +8,12 @@
 
 (defun set-rnd-state (i)
   (declare (fixnum i))
-  (if (or #+SBCL t nil)
-      (setf *random-state* (sb-ext:seed-random-state i))
-      (warn "rnd:state is only implemented for SBCL. see src/rnd.lisp
-             to implement state for your environment.")))
+   #+SBCL
+   (setf *random-state* (sb-ext:seed-random-state i))
+
+   #+(not SBCL)
+   (warn "rnd:state is only implemented for SBCL. see src/rnd.lisp
+          to implement state for your environment."))
 
 
 (defun make-rnd-state ()

--- a/src/various.lisp
+++ b/src/various.lisp
@@ -6,15 +6,9 @@
 
 (declaim (type double-float PII PI5))
 
-#:+SBCL
-(defconstant PII (the double-float #.(* PI 2d0)))
-#:+SBCL
-(defconstant PI5 (the double-float #.(* PI 0.5d0)))
-
-#:+ECL
-(defconstant PII (the double-float #.(* (float PI 1.0d0) 2d0)))
-#:+ECL
-(defconstant PI5 (the double-float #.(* (float PI 1.0d0) 0.5d0)))
+(defconstant PI* #.(coerce pi 'double-float)) ; so that there is a double pi available
+(defconstant PII #.(coerce (* pi 2d0) 'double-float))
+(defconstant PI5 #.(coerce (* pi 0.5d0) 'double-float))
 
 (defun v? (&optional silent)
   (if silent (slot-value (asdf:find-system 'weir) 'asdf:version)

--- a/src/various.lisp
+++ b/src/various.lisp
@@ -40,7 +40,6 @@
   #+ccl (ccl:quitstatus)
   #+clisp (ext:quitstatus)
   #+cmu (unix:unix-exit status)
-  #+ecl (ext:quitstatus)
   #+abcl (ext:quit:status status)
   #+allegro (excl:exitstatus :quiet t)
   #+gcl (common-lisp-user::bye status)

--- a/src/various.lisp
+++ b/src/various.lisp
@@ -6,8 +6,15 @@
 
 (declaim (type double-float PII PI5))
 
+#:+SBCL
 (defconstant PII (the double-float #.(* PI 2d0)))
+#:+SBCL
 (defconstant PI5 (the double-float #.(* PI 0.5d0)))
+
+#:+ECL
+(defconstant PII (the double-float #.(* (float PI 1.0d0) 2d0)))
+#:+ECL
+(defconstant PI5 (the double-float #.(* (float PI 1.0d0) 0.5d0)))
 
 (defun v? (&optional silent)
   (if silent (slot-value (asdf:find-system 'weir) 'asdf:version)

--- a/src/various.lisp
+++ b/src/various.lisp
@@ -43,7 +43,7 @@
   #+abcl (ext:quit:status status)
   #+allegro (excl:exitstatus :quiet t)
   #+gcl (common-lisp-user::bye status)
-  #+ecl (ext:quitstatus))
+  #+ecl (ext:quit status))
 
 
 ;https://github.com/inconvergent/weir/pull/1/commits/4a1df51914800c78cb34e8194222185ebde12388


### PR DESCRIPTION
```
;;; Warning: 
;;; in file various.lisp, position 144 
;;; at (DEFCONSTANT PII ...) 
;;; ! The expression 6.283185307179586477l0 is not of the expected type DOUBLE-FLOAT 
;;; Warning: 
;;; in file various.lisp, position 195
;;; at (DEFCONSTANT PI5 ...) 
;;; ! The expression 1.5707963267948966193l0 is not of the expected type DOUBLE-FLOAT
```

ECL 'long-float' has more precision than 'double-float'

While packing for the Guix I found the issue to build `weir` system on ECL

Reference  https://issues.guix.gnu.org/47851